### PR TITLE
Allow to run from FW 2.1 and auto-dump otp.bin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "CakeHax"]
 	path = CakeHax
 	url = https://github.com/mid-kid/CakeHax.git
+[submodule "2xrsa"]
+	path = 2xrsa
+	url = https://github.com/b1l1s/2xrsa.git
+	ignore = dirty

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ version := $(shell git describe --abbrev=0 --tags)
 dir_source := source
 dir_mset := CakeHax
 dir_ninjhax := CakeBrah
+dir_2xrsa := 2xrsa
 dir_build := build
 dir_out := out
 
@@ -33,6 +34,9 @@ launcher: $(dir_out)/$(name).dat
 .PHONY: a9lh
 a9lh: $(dir_out)/arm9loaderhax.bin
 
+.PHONY: 2xrsa
+2xrsa: $(dir_out)/arm9.bin $(dir_out)/arm11.bin
+
 .PHONY: ninjhax
 ninjhax: $(dir_out)/3ds/$(name)
 
@@ -43,6 +47,7 @@ release: $(dir_out)/$(name).zip
 clean:
 	@$(MAKE) $(FLAGS) -C $(dir_mset) clean
 	@$(MAKE) $(FLAGS) -C $(dir_ninjhax) clean
+	@$(MAKE) -C $(dir_2xrsa) clean
 	@rm -rf $(dir_out) $(dir_build)
 
 $(dir_out):
@@ -56,13 +61,20 @@ $(dir_out)/$(name).dat: $(dir_build)/main.bin $(dir_out)
 $(dir_out)/arm9loaderhax.bin: $(dir_build)/main.bin $(dir_out)
 	@cp -av $(dir_build)/main.bin $@
 
+$(dir_out)/arm9.bin: $(dir_build)/main.bin $(dir_out)
+	@cp -av $(dir_build)/main.bin $@
+
+$(dir_out)/arm11.bin:
+	@$(MAKE) -C $(dir_2xrsa)
+	@cp -av $(dir_2xrsa)/bin/arm11.bin $@
+
 $(dir_out)/3ds/$(name): $(dir_out)
 	@mkdir -p $(dir_out)/3ds/$(name)
 	@$(MAKE) $(FLAGS) -C $(dir_ninjhax)
 	@mv $(dir_out)/$(name).3dsx $@
 	@mv $(dir_out)/$(name).smdh $@
 
-$(dir_out)/$(name).zip: launcher a9lh ninjhax
+$(dir_out)/$(name).zip: launcher a9lh ninjhax 2xrsa
 	@cd $(dir_out) && zip -9 -r $(name) *
 
 $(dir_build)/main.bin: $(dir_build)/main.elf

--- a/source/fatfs/ffconf.h
+++ b/source/fatfs/ffconf.h
@@ -16,7 +16,7 @@
 /  data transfer. */
 
 
-#define _FS_READONLY	1
+#define _FS_READONLY	0
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()

--- a/source/fs.c
+++ b/source/fs.c
@@ -12,6 +12,21 @@ u32 mountSD(void){
     return 1;
 }
 
+u32 fileWrite(void *orig, const char *path, u32 size){
+    FRESULT fr;
+    FIL fp;
+    unsigned int bw = 0;
+
+    if(!size) return 0;
+    fr = f_open(&fp, path, FA_WRITE | FA_CREATE_ALWAYS);
+    if(fr == FR_OK){
+        fr = f_write(&fp, orig, size, &bw);
+    }
+
+    f_close(&fp);
+    return (fr || (bw != size)) ? 0 : 1;
+}
+
 u32 fileRead(void *dest, const char *path, u32 size){
     FRESULT fr;
     FIL fp;

--- a/source/fs.h
+++ b/source/fs.h
@@ -7,5 +7,6 @@
 #include "types.h"
 
 u32 mountSD(void);
+u32 fileWrite(void *orig, const char *path, u32 size);
 u32 fileRead(void *dest, const char *path, u32 size);
 u32 fileSize(const char *path);

--- a/source/installer.c
+++ b/source/installer.c
@@ -52,9 +52,19 @@ void installer(void){
     if(!a9lhBoot){
         //Read OTP
         path = "a9lh/otp.bin";
-        if(fileSize(path) != 256)
-            shutdown(1, "Error: otp.bin doesn't exist or has a wrong size");
-        fileRead((void *)OTP_OFFSET, path, 256);
+        if(!fileSize(path)) {
+            //File not found, look in memory
+            u8 zeroes[256] = { 0 };
+            if(memcmp((void *)OTP_FROM_MEM, zeroes, 256) == 0)
+                shutdown(1, "Error: otp.bin doesn't exist and can't be dumped");
+            fileWrite((void *)OTP_FROM_MEM, path, 256);
+            memcpy((void *)OTP_OFFSET, (void*)OTP_FROM_MEM, 256);
+        } else if(fileSize(path) != 256) {
+            //File found, but bad size
+            shutdown(1, "Error: otp.bin has a wrong size");
+        } else {
+            fileRead((void *)OTP_OFFSET, path, 256);
+        }
     }
 
     //Setup the key sector de/encryption with the SHA register or otp.bin

--- a/source/installer.h
+++ b/source/installer.h
@@ -5,6 +5,7 @@
 #define PDN_MPCORE_CFG     (*(vu8 *)0x10140FFC)
 #define PDN_SPI_CNT        (*(vu8 *)0x101401C0)
 
+#define OTP_FROM_MEM 0x10012000
 #define OTP_OFFSET 0x24000000
 #define SECTOR_OFFSET 0x24100000
 #define FIRM0_OFFSET 0x24200000


### PR DESCRIPTION
This pull request allows to run SafeA9lhInstaller from FW 2.1. If the otp.bin does not exist, it will be read from memory and automatically dumped to a file.

Tested by yours truly, @al3x10m